### PR TITLE
Stopped the ISR for the initialization of SD during RB

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -925,7 +925,7 @@ bool EmotiBit::printConfigInfo(File &file, String datetimeString) {
 	String source_id = "EmotiBit FeatherWing";
 	int hardware_version = (int)_version;
 	String feather_version = "Adafruit Feather M0 WiFi";
-	String firmware_version = "0.4.3";
+	String firmware_version = "0.5.5";
 
 	const uint16_t bufferSize = 1024;
 

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -609,6 +609,7 @@ void parseIncomingMessages() {
 					isLoggableMessage = true;
 				}
 				else if (typeTag.equals("RB")) { // Recording begin
+					stopTimer();
 					isLoggableMessage = true;
 					String datetimeString = receivedMessage.substring(dataStartChar, receivedMessage.length() - 1);
 					// Write the configuration info to json file
@@ -634,6 +635,9 @@ void parseIncomingMessages() {
 					else {
 						Serial.println("Failed to open data file for writing");
 					}
+					sendTimerStart = millis();
+					requestTimestampTimerStart = millis();
+					startTimer(BASE_SAMPLING_FREQ);
 				}
 				else if (typeTag.equals("RE")) { // Recording end
 					isLoggableMessage = true;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=0.5.4
+version=0.5.5
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
### Bug fixes
- SD could cause system crash after RB (Record Begin) on certain FeatherWings, including CharliePlex, due to longer ISR times or greater resource consumption
- The ISR timer is now stopped at reception of RB and restarted after basic file management
- Tested on the CharliePlex, NeoPixel, and no additional FeatherWings