### PR TITLE
Hibernate and Recording

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -925,7 +925,7 @@ bool EmotiBit::printConfigInfo(File &file, String datetimeString) {
 	String source_id = "EmotiBit FeatherWing";
 	int hardware_version = (int)_version;
 	String feather_version = "Adafruit Feather M0 WiFi";
-	String firmware_version = "0.5.7";
+	String firmware_version = "0.5.8";
 
 	const uint16_t bufferSize = 1024;
 

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -184,7 +184,11 @@ uint8_t EmotiBit::setup(Version version, size_t bufferCapacity) {
 	Serial.print("edrAmplification = "); Serial.println(edrAmplification);
 
 	// Setup switch
-	pinMode(switchPin, INPUT);
+	if (switchPin != LED_BUILTIN) {
+		// If the LED_BUILTIN and switchpin are the same leave it as it was
+		// Otherwise setup the input
+		pinMode(switchPin, INPUT);
+	}
 
 	// Setup battery Reading
 	pinMode(_batteryReadPin, INPUT);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -127,6 +127,7 @@ public:
 	length
   };
   
+  uint8_t _analogEnablePin;
   Si7013 tempHumiditySensor;
 	uint8_t switchPin;
 	PPGSettings ppgSettings;
@@ -182,7 +183,6 @@ private:
 	SamplingRates _samplingRates;
 	SamplesAveraged _samplesAveraged;
 	uint8_t _batteryReadPin;
-  uint8_t _analogEnablePin;
   uint8_t _edlPin;
   uint8_t _edrPin;
 	float _vcc;

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -446,44 +446,6 @@ void setup() {
 	// ToDo: utilize separate strings for SD card writable messages vs transmit acks
 
 	sendResetPacket = true;
-#if 0
-	//GSRToggle; should be done with _analogEnablePin
-	pinMode(5, OUTPUT);
-	digitalWrite(5, HIGH);
-
-	//PPGToggle
-	emotibit.ppgSensor.shutDown();
-
-	//IMU Suspend Mode
-	//Suspend Accelerometer
-	BMI160.setRegister(BMI160_RA_CMD, 0x10); //set acc pmu mode to suspend: 0001 0000
-	delay(BMI160_READ_WRITE_DELAY);
-	uint8_t pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_ACC_PMU_STATUS_BIT)!= 0) && (emotibit.getBit(pmu, BMI160_ACC_PMU_STATUS_BIT+1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
-	//Suspend Gyro
-	BMI160.setRegister(BMI160_RA_CMD, 0x14); //set gyr pmu mode to suspend: 0001 0100
-	delay(BMI160_READ_WRITE_DELAY);
-	pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT) != 0) && (emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT + 1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
-
-	//Suspend Mag
-	BMI160.setRegister(BMI160_RA_CMD, 0x18); //set mag pmu mode to suspend: 0001 1000
-	delay(BMI160_AUX_COM_DELAY);
-	pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT) != 0) && (emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT + 1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
-#endif
 }
 
 String createPacketHeader(uint32_t timestamp, String typeTag, size_t dataLen) {
@@ -1061,10 +1023,10 @@ void hibernate() {
 	}
 	WiFi.end();
 #endif
-#if 1
-	//GSRToggle; should be done with _analogEnablePin
-	pinMode(5, OUTPUT);
-	digitalWrite(5, HIGH);
+
+	//GSRToggle, write 1 to the PMOS
+	pinMode(emotibit._analogEnablePin, OUTPUT);
+	digitalWrite(emotibit._analogEnablePin, HIGH);
 
 	//PPGToggle
 	emotibit.ppgSensor.shutDown();
@@ -1098,13 +1060,10 @@ void hibernate() {
 		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
 		delay(BMI160_READ_WRITE_DELAY);
 	}
-#endif
+
 	while (ledPinBusy)
 	pinMode(LED_BUILTIN, OUTPUT);
 
-	// ToDo: 
-	//	Shutdown IMU
-	//	Consider more low level power management
 
 	while (true) {
 		

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -1021,6 +1021,10 @@ void printWiFiStatus() {
 void hibernate() {
 	stopTimer();
 
+  //PPGToggle
+  // For an unknown reason, this need to be before WiFi diconnect/end
+  emotibit.ppgSensor.shutDown();
+
 #ifdef SEND_UDP || SEND_TCP
 	if (wifiStatus == WL_CONNECTED) {
 		WiFi.disconnect();
@@ -1032,8 +1036,7 @@ void hibernate() {
 	pinMode(emotibit._analogEnablePin, OUTPUT);
 	digitalWrite(emotibit._analogEnablePin, HIGH);
 
-	//PPGToggle
-	emotibit.ppgSensor.shutDown();
+
 
 	//IMU Suspend Mode
 	BMI160.suspendIMU();

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -153,6 +153,9 @@ struct AcquireData {
 	bool ppg = true;
 } acquireData;
 
+//If this function is called in Setup(), SD writing is automatically initiated without
+// a start message from the GUI or wireless com. Could cause file overwrites do to file naming.
+// Probably causes BAD_THINGS if RB is sent when this function is called.
 void autoSDwrite() {
 	String datetimeString = "EmotiBitDataSave";
 	// Write the configuration info to json file
@@ -1014,6 +1017,7 @@ void printWiFiStatus() {
 //	return &stack_dummy - sbrk(0);
 //}
 
+//Currently Down to ~2.5mA draw (0.01 W)
 void hibernate() {
 	stopTimer();
 
@@ -1032,34 +1036,7 @@ void hibernate() {
 	emotibit.ppgSensor.shutDown();
 
 	//IMU Suspend Mode
-	//Suspend Accelerometer
-	BMI160.setRegister(BMI160_RA_CMD, 0x10); //set acc pmu mode to suspend: 0001 0000
-	delay(BMI160_READ_WRITE_DELAY);
-	uint8_t pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_ACC_PMU_STATUS_BIT) != 0) && (emotibit.getBit(pmu, BMI160_ACC_PMU_STATUS_BIT + 1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
-	//Suspend Gyro
-	BMI160.setRegister(BMI160_RA_CMD, 0x14); //set gyr pmu mode to suspend: 0001 0100
-	delay(BMI160_READ_WRITE_DELAY);
-	pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT) != 0) && (emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT + 1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
-
-	//Suspend Mag
-	BMI160.setRegister(BMI160_RA_CMD, 0x18); //set mag pmu mode to suspend: 0001 1000
-	delay(BMI160_AUX_COM_DELAY);
-	pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-	delay(BMI160_READ_WRITE_DELAY);
-	while ((emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT) != 0) && (emotibit.getBit(pmu, BMI160_GYR_PMU_STATUS_BIT + 1) != 0)) {
-		pmu = BMI160.getRegister(BMI160_RA_PMU_STATUS);
-		delay(BMI160_READ_WRITE_DELAY);
-	}
+	BMI160.suspendIMU();
 
 	while (ledPinBusy)
 	pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -1019,32 +1019,39 @@ void printWiFiStatus() {
 
 //Currently Down to ~2.5mA draw (0.01 W)
 void hibernate() {
+	Serial.println("hibernate()");
+	Serial.println("Stopping timer...");
 	stopTimer();
 
   //PPGToggle
   // For an unknown reason, this need to be before WiFi diconnect/end
-  emotibit.ppgSensor.shutDown();
+	Serial.println("Shutting down ppg...");
+	emotibit.ppgSensor.shutDown();
 
 #ifdef SEND_UDP || SEND_TCP
 	if (wifiStatus == WL_CONNECTED) {
+		Serial.println("Disconnecting WiFi...");
 		WiFi.disconnect();
 	}
+	Serial.println("Ending WiFi...");
 	WiFi.end();
 #endif
 
-	//GSRToggle, write 1 to the PMOS
+	//GSRToggle, write 1 to the PMO
+	Serial.println("Disabling analog circuitry...");
 	pinMode(emotibit._analogEnablePin, OUTPUT);
 	digitalWrite(emotibit._analogEnablePin, HIGH);
 
 
 
 	//IMU Suspend Mode
+	Serial.println("Suspending IMU...");
 	BMI160.suspendIMU();
 
 	while (ledPinBusy)
 	pinMode(LED_BUILTIN, OUTPUT);
 
-
+	Serial.println("Entering sleep loop...");
 	while (true) {
 		
 		digitalWrite(LED_BUILTIN, LOW); // Show we're asleep
@@ -1288,7 +1295,7 @@ void updateWiFi() {
 		wifiReady = false;
 		socketReady = false;
 	}
-#if 1
+#if 0
 	//Serial.println("<<<<<<< updateWiFi >>>>>>>");
 	Serial.println("------- WiFi Status -------");
 	Serial.println(millis());

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -189,13 +189,19 @@ uint8_t printLen[(uint8_t)EmotiBit::DataType::length];
 bool sendData[(uint8_t)EmotiBit::DataType::length];
 
 void setup() {
-	Serial.println("setup()");
-
 	pinMode(LED_BUILTIN, OUTPUT);
 	digitalWrite(LED_BUILTIN, HIGH);
 	ledOn = true;
 
 	setupTimerStart = millis();
+
+	Serial.begin(SERIAL_BAUD);
+	//while (!Serial);
+	Serial.println("Serial started");
+
+	delay(500);
+
+	Serial.println("setup()");
 
 	if (!outputMessage.reserve(OUT_MESSAGE_RESERVE_SIZE)) {
 		Serial.println("Failed to reserve memory for output");
@@ -203,12 +209,6 @@ void setup() {
 			hibernate();
 		}
 	}
-
-	delay(500);
-
-	Serial.begin(SERIAL_BAUD);
-	//while (!Serial);
-	Serial.println("Serial started");
 
 	delay(500);
 

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -203,6 +203,24 @@ void setup() {
 
 	Serial.println("setup()");
 
+#if defined(SEND_UDP) || defined(SEND_TCP)
+	//Configure pins for Adafruit ATWINC1500 Feather
+	WiFi.setPins(8, 7, 4, 2);
+	//WiFi.noLowPowerMode();
+	WiFi.lowPowerMode();
+
+	//WiFi.maxLowPowerMode();
+	// check for the presence of the shield:
+	if (WiFi.status() == WL_NO_SHIELD) {
+		Serial.println("WiFi shield not present");
+		// don't continue:
+		while (true) {
+			hibernate();
+		}
+	}
+#endif
+
+
 	if (!outputMessage.reserve(OUT_MESSAGE_RESERVE_SIZE)) {
 		Serial.println("Failed to reserve memory for output");
 		while (true) {
@@ -262,22 +280,6 @@ void setup() {
 	//printDirectory(root, 0);
 	//Serial.println("done!");
 
-#if defined(SEND_UDP) || defined(SEND_TCP)
-	//Configure pins for Adafruit ATWINC1500 Feather
-	WiFi.setPins(8, 7, 4, 2);
-	//WiFi.noLowPowerMode();
-	WiFi.lowPowerMode();
-  
-	//WiFi.maxLowPowerMode();
-	// check for the presence of the shield:
-	if (WiFi.status() == WL_NO_SHIELD) {
-		Serial.println("WiFi shield not present");
-		// don't continue:
-		while (true) {
-			hibernate();
-		}
-	}
-#endif
 
 #ifdef SEND_UDP
 	// attempt to connect to WiFi network:


### PR DESCRIPTION
### Bug Fixes and Improvements
- Updates to hibernate()
   - shut off power to GSR and thermistor
   - put accelerometer, gyro, and magnetometer into suspend mode
   - down to ~2.5mA draw (0.01 W) from possibly ~ 7-9 mA
      - Includes the ~1mA contribution of the Feather M0
- Proper support for SD writing without WiFi connection
   - Move some const definitions and added more #ifdefs
   - Added autoSDwrite(), which should be called in setup()
### Compatibility
- Should be used with ofxEmotiBit v0.6.0+
- Should be used with EmotiBit BMI160 v0.2.0+